### PR TITLE
Maintenance Window: Device simulator changes.

### DIFF
--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
@@ -21,6 +21,7 @@ import org.eclipse.hawkbit.dmf.amqp.api.MessageType;
 import org.eclipse.hawkbit.dmf.json.model.DmfActionStatus;
 import org.eclipse.hawkbit.dmf.json.model.DmfActionUpdateStatus;
 import org.eclipse.hawkbit.dmf.json.model.DmfAttributeUpdate;
+import org.eclipse.hawkbit.simulator.ActionType;
 import org.eclipse.hawkbit.simulator.SimulationProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,9 +76,14 @@ public class DmfSenderService extends MessageService {
      *            the simulated update object
      * @param updateResultMessages
      *            a description according the update process
+     * @param actionType
+     *            indicating whether to download and install or skip
+     *            installation due to maintenance window.
      */
-    public void finishUpdateProcess(final SimulatedUpdate update, final List<String> updateResultMessages) {
-        final Message updateResultMessage = createUpdateResultMessage(update, DmfActionStatus.FINISHED,
+    public void finishUpdateProcess(final SimulatedUpdate update, final List<String> updateResultMessages,
+            final ActionType actionType) {
+        final Message updateResultMessage = createUpdateResultMessage(update,
+                actionType == ActionType.DOWNLOAD_AND_SKIP ? DmfActionStatus.DOWNLOADED : DmfActionStatus.FINISHED,
                 updateResultMessages);
         sendMessage(spExchange, updateResultMessage);
     }


### PR DESCRIPTION
This is the companion to [hawkBit's pull request #535, formerly #245](https://github.com/eclipse/hawkbit/pull/535)

Device simulator changes to use maintenance window for DMF devices.

- Additional handling added to SpReciever for DOWNLOAD_AND_UPDATE and
DOWNLOAD_AND_SKIP.

- SpSender sends ActionStatus.DOWNLOADED or ActionStatus.FINISHED based
on action type.

- Simulator update thread waits at 80% unless it gets
DOWNLOAD_AND_UPDATE event explicitly.

Signed-off-by: Christian Storm <christian.storm@siemens.com>
Signed-off-by: Himanshu Kumar Singh <himanshu.singh@siemens.com>
Signed-off-by: Raju HS <raju.hs@siemens.com>