### PR TITLE
Fix: DMF is optional and can be disabled.

### DIFF
--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatedDeviceFactory.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatedDeviceFactory.java
@@ -40,7 +40,7 @@ public class SimulatedDeviceFactory {
     @Autowired
     private DeviceSimulatorUpdater deviceUpdater;
 
-    @Autowired
+    @Autowired(required = false)
     private DmfSenderService spSenderService;
 
     @Autowired


### PR DESCRIPTION
So the bean needs to be optional.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>