### PR TITLE
Device simulator amqp configuration extension

### DIFF
--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/AmqpProperties.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/AmqpProperties.java
@@ -51,6 +51,8 @@ public class AmqpProperties {
      */
     private int deadLetterTtl = 60_000;
 
+    private String customVhost;
+
     public boolean isCheckDmfHealth() {
         return checkDmfHealth;
     }
@@ -89,5 +91,13 @@ public class AmqpProperties {
 
     public void setEnabled(final boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getCustomVhost() {
+        return customVhost;
+    }
+
+    public void setCustomVhost(final String customVhost) {
+        this.customVhost = customVhost;
     }
 }


### PR DESCRIPTION
* Allow to specify the RabbitMQ custom virtual host per property `hawkbit.device.simulator.amqp.customVhost` in case it is not given by cloud binding

Signed-off-by: Bogdan Bondar <Bogdan.Bondar@bosch-si.com>