### PR TITLE
Fixed startup issue if AMQP interface is disabled

### DIFF
--- a/hawkbit-device-simulator/README.md
+++ b/hawkbit-device-simulator/README.md
@@ -12,19 +12,6 @@ Or:
 run org.eclipse.hawkbit.simulator.DeviceSimulator
 ```
 
-## Deploy to cloud foundry environment
-
-- Go to ```target``` subfolder.
-- Run ```cf push```
-
-## Notes
-
-The simulator has user authentication enabled by default. The default credentials are:
-* Username : admin
-* Password : admin
-
-This can be configured/disabled by spring boot properties
-
 ## hawkBit APIs
 
 The simulator supports `DDI` as well as the `DMF` integration APIs.

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/AllowAllWebSecurityConfig.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/AllowAllWebSecurityConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.simulator;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * Spring security configuration to grant access for all incomming requests.
+ */
+@Configuration
+public class AllowAllWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(final HttpSecurity httpSec) throws Exception {
+        httpSec.csrf().disable().authorizeRequests().antMatchers("/**").permitAll().anyRequest().authenticated();
+    }
+}

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
@@ -44,12 +44,12 @@ public class UpdateStatus {
     }
 
     /**
-     * Constructor including status message.
+     * Constructor including status messages.
      * 
      * @param responseStatus
      *            of the update
-     * @param messages
-     *            of the update status
+     * @param statusMessages
+     *            list of status messages
      */
     public UpdateStatus(final ResponseStatus responseStatus, final List<String> statusMessages) {
         this(responseStatus);

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
@@ -76,9 +76,6 @@ public class DmfSenderService extends MessageService {
      *            the simulated update object
      * @param updateResultMessages
      *            a description according the update process
-     * @param actionType
-     *            indicating whether to download and install or skip
-     *            installation due to maintenance window.
      */
     public void finishUpdateProcess(final SimulatedUpdate update, final List<String> updateResultMessages) {
         final Message updateResultMessage = createUpdateResultMessage(update, DmfActionStatus.FINISHED,

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/MessageService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/MessageService.java
@@ -35,8 +35,6 @@ public class MessageService {
      *            the rabbit template
      * @param amqpProperties
      *            the amqp properties
-     * @param messageConverter
-     *            the message converter
      */
     public MessageService(final RabbitTemplate rabbitTemplate, final AmqpProperties amqpProperties) {
         this.rabbitTemplate = rabbitTemplate;

--- a/hawkbit-device-simulator/src/main/resources/application.properties
+++ b/hawkbit-device-simulator/src/main/resources/application.properties
@@ -30,8 +30,6 @@ hawkbit.device.simulator.attributes[2].value=${random.value}
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
-management.endpoint.health.show-details=when-authorized
-management.endpoint.health.roles=SYSTEM_ADMIN
 
 ## Configuration for local RabbitMQ integration
 spring.rabbitmq.username=guest
@@ -40,8 +38,5 @@ spring.rabbitmq.virtualHost=/
 spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672
 spring.rabbitmq.dynamic=true
-
-spring.security.user.name=admin
-spring.security.user.password={noop}admin
 
 server.port=8083


### PR DESCRIPTION
If `hawkbit.device.simulator.amqp.enabled` is set to `false` there is no bean `DmfSenderService` so we have to deal with that. 

For the sake of usability I also removed the need to provide credentials.