### PR TITLE
Added property to disable authorization header for file download

### DIFF
--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -37,6 +37,7 @@ import org.eclipse.hawkbit.simulator.UpdateStatus.ResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -62,6 +63,9 @@ public class DeviceSimulatorUpdater {
 
     @Autowired
     private DeviceSimulatorRepository repository;
+
+    @Value("${hawkbit.device.simulator.authTokenInDownloadUrl.enabled:true}")
+    private static boolean authTokenInDownloadUrlEnabled;
 
     /**
      * Starting an simulated update process of an simulated device.
@@ -160,8 +164,13 @@ public class DeviceSimulatorUpdater {
 
             LOGGER.info("Simulate downloads for {}", device.getId());
 
-            modules.forEach(module -> module.getArtifacts().forEach(
-                    artifact -> handleArtifact(device.getTargetSecurityToken(), gatewayToken, status, artifact)));
+            modules.forEach(module -> module.getArtifacts().forEach(artifact -> {
+                if (authTokenInDownloadUrlEnabled) {
+                    handleArtifact(device.getTargetSecurityToken(), gatewayToken, status, artifact);
+                } else {
+                    handleArtifact(null, null, status, artifact);
+                }
+            }));
 
             final UpdateStatus result = new UpdateStatus(ResponseStatus.DOWNLOADED);
             result.getStatusMessages().add("Simulator: Download complete!");

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -102,7 +102,7 @@ public class DeviceSimulatorUpdater {
         device.setTargetSecurityToken(targetSecurityToken);
 
         threadPool.schedule(new DeviceSimulatorUpdateThread(device, callback, modules, actionType, gatewayToken,
-                simulationProperties.isAddAuthTokenInDownloadUrl()), 2_000, TimeUnit.MILLISECONDS);
+                simulationProperties.isDownloadAuthenticationEnabled()), 2_000, TimeUnit.MILLISECONDS);
     }
 
     private static final class DeviceSimulatorUpdateThread implements Runnable {
@@ -119,17 +119,17 @@ public class DeviceSimulatorUpdater {
         private final UpdaterCallback callback;
         private final List<DmfSoftwareModule> modules;
         private final String gatewayToken;
-        private final boolean authTokenInDownloadUrlEnabled;
+        private final boolean downloadAuthenticationEnabled;
 
         private DeviceSimulatorUpdateThread(final AbstractSimulatedDevice device, final UpdaterCallback callback,
                 final List<DmfSoftwareModule> modules, final EventTopic actionType, final String gatewayToken,
-                final boolean authTokenInDownloadUrlEnabled) {
+                final boolean downloadAuthenticationEnabled) {
             this.device = device;
             this.callback = callback;
             this.modules = modules;
             this.actionType = actionType;
             this.gatewayToken = gatewayToken;
-            this.authTokenInDownloadUrlEnabled = authTokenInDownloadUrlEnabled;
+            this.downloadAuthenticationEnabled = downloadAuthenticationEnabled;
         }
 
         @Override
@@ -167,7 +167,7 @@ public class DeviceSimulatorUpdater {
             LOGGER.info("Simulate downloads for {}", device.getId());
 
             modules.forEach(module -> module.getArtifacts().forEach(artifact -> {
-                if (authTokenInDownloadUrlEnabled) {
+                if (downloadAuthenticationEnabled) {
                     handleArtifact(device.getTargetSecurityToken(), gatewayToken, status, artifact);
                 } else {
                     handleArtifact(null, null, status, artifact);

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -65,7 +65,7 @@ public class DeviceSimulatorUpdater {
     private DeviceSimulatorRepository repository;
 
     @Value("${hawkbit.device.simulator.authTokenInDownloadUrl.enabled:true}")
-    private static boolean authTokenInDownloadUrlEnabled;
+    private boolean authTokenInDownloadUrlEnabled;
 
     /**
      * Starting an simulated update process of an simulated device.
@@ -102,8 +102,8 @@ public class DeviceSimulatorUpdater {
 
         device.setTargetSecurityToken(targetSecurityToken);
 
-        threadPool.schedule(new DeviceSimulatorUpdateThread(device, callback, modules, actionType, gatewayToken), 2_000,
-                TimeUnit.MILLISECONDS);
+        threadPool.schedule(new DeviceSimulatorUpdateThread(device, callback, modules, actionType, gatewayToken,
+                authTokenInDownloadUrlEnabled), 2_000, TimeUnit.MILLISECONDS);
     }
 
     private static final class DeviceSimulatorUpdateThread implements Runnable {
@@ -120,14 +120,17 @@ public class DeviceSimulatorUpdater {
         private final UpdaterCallback callback;
         private final List<DmfSoftwareModule> modules;
         private final String gatewayToken;
+        private final boolean authTokenInDownloadUrlEnabled;
 
         private DeviceSimulatorUpdateThread(final AbstractSimulatedDevice device, final UpdaterCallback callback,
-                final List<DmfSoftwareModule> modules, final EventTopic actionType, final String gatewayToken) {
+                final List<DmfSoftwareModule> modules, final EventTopic actionType, final String gatewayToken,
+                final boolean authTokenInDownloadUrlEnabled) {
             this.device = device;
             this.callback = callback;
             this.modules = modules;
             this.actionType = actionType;
             this.gatewayToken = gatewayToken;
+            this.authTokenInDownloadUrlEnabled = authTokenInDownloadUrlEnabled;
         }
 
         @Override

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -37,7 +37,6 @@ import org.eclipse.hawkbit.simulator.UpdateStatus.ResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -64,8 +63,8 @@ public class DeviceSimulatorUpdater {
     @Autowired
     private DeviceSimulatorRepository repository;
 
-    @Value("${hawkbit.device.simulator.authTokenInDownloadUrl.enabled:true}")
-    private boolean authTokenInDownloadUrlEnabled;
+    @Autowired
+    private SimulationProperties simulationProperties;
 
     /**
      * Starting an simulated update process of an simulated device.
@@ -103,7 +102,7 @@ public class DeviceSimulatorUpdater {
         device.setTargetSecurityToken(targetSecurityToken);
 
         threadPool.schedule(new DeviceSimulatorUpdateThread(device, callback, modules, actionType, gatewayToken,
-                authTokenInDownloadUrlEnabled), 2_000, TimeUnit.MILLISECONDS);
+                simulationProperties.isAddAuthTokenInDownloadUrl()), 2_000, TimeUnit.MILLISECONDS);
     }
 
     private static final class DeviceSimulatorUpdateThread implements Runnable {

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
@@ -37,6 +37,13 @@ public class SimulationProperties {
     private String defaultTenant = "DEFAULT";
 
     /**
+     * Set to <code>true</code> if the the target or gateway auth token should
+     * be added to the download url as an authorization header. Activated by
+     * default but may be worth to disable if not needed.
+     */
+    private boolean addAuthTokenInDownloadUrl = true;
+
+    /**
      * List of tenants where the simulator should auto start simulations after
      * startup.
      */
@@ -50,6 +57,14 @@ public class SimulationProperties {
 
     public void setDefaultTenant(final String defaultTenant) {
         this.defaultTenant = defaultTenant;
+    }
+
+    public boolean isAddAuthTokenInDownloadUrl() {
+        return addAuthTokenInDownloadUrl;
+    }
+
+    public void setAddAuthTokenInDownloadUrl(final boolean addAuthTokenInDownloadUrl) {
+        this.addAuthTokenInDownloadUrl = addAuthTokenInDownloadUrl;
     }
 
     public List<Attribute> getAttributes() {

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
@@ -37,11 +37,11 @@ public class SimulationProperties {
     private String defaultTenant = "DEFAULT";
 
     /**
-     * Set to <code>true</code> if the the target or gateway auth token should
-     * be added to the download url as an authorization header. Activated by
+     * Set to <code>true</code> if the target or gateway auth token should be
+     * added to the download request as an authorization header. Activated by
      * default but may be worth to disable if not needed.
      */
-    private boolean addAuthTokenInDownloadUrl = true;
+    private boolean downloadAuthenticationEnabled = true;
 
     /**
      * List of tenants where the simulator should auto start simulations after
@@ -59,12 +59,12 @@ public class SimulationProperties {
         this.defaultTenant = defaultTenant;
     }
 
-    public boolean isAddAuthTokenInDownloadUrl() {
-        return addAuthTokenInDownloadUrl;
+    public boolean isDownloadAuthenticationEnabled() {
+        return downloadAuthenticationEnabled;
     }
 
-    public void setAddAuthTokenInDownloadUrl(final boolean addAuthTokenInDownloadUrl) {
-        this.addAuthTokenInDownloadUrl = addAuthTokenInDownloadUrl;
+    public void setDownloadAuthenticationEnabled(final boolean downloadAuthenticationEnabled) {
+        this.downloadAuthenticationEnabled = downloadAuthenticationEnabled;
     }
 
     public List<Attribute> getAttributes() {


### PR DESCRIPTION
In case of third-party services we don't want to pass the Authorization Header with Target or Gateway token when downloading the artifact from remote repository, because it can conflict with the signed url.

Signed-off-by: Bogdan Bondar <Bogdan.Bondar@bosch-si.com>