### PR TITLE
Reflect various changes of upcoming hawkBit 0.3.0M7

### DIFF
--- a/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyUI.java
+++ b/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyUI.java
@@ -8,17 +8,6 @@ package org.eclipse.hawkbit.app;
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
-import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
-import org.eclipse.hawkbit.ui.ErrorView;
-import org.eclipse.hawkbit.ui.UiProperties;
-import org.eclipse.hawkbit.ui.components.NotificationUnreadButton;
-import org.eclipse.hawkbit.ui.menu.DashboardMenu;
-import org.eclipse.hawkbit.ui.push.EventPushStrategy;
-import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.vaadin.spring.events.EventBus.UIEventBus;
-
 import com.vaadin.annotations.Push;
 import com.vaadin.annotations.Theme;
 import com.vaadin.annotations.Title;
@@ -26,6 +15,18 @@ import com.vaadin.shared.communication.PushMode;
 import com.vaadin.shared.ui.ui.Transport;
 import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.navigator.SpringViewProvider;
+
+import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
+import org.eclipse.hawkbit.ui.ErrorView;
+import org.eclipse.hawkbit.ui.UiProperties;
+import org.eclipse.hawkbit.ui.components.NotificationUnreadButton;
+import org.eclipse.hawkbit.ui.menu.DashboardMenu;
+import org.eclipse.hawkbit.ui.push.EventPushStrategy;
+import org.eclipse.hawkbit.ui.push.UIEventProvider;
+import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Example hawkBit UI implementation.
@@ -45,11 +46,11 @@ public class MyUI extends AbstractHawkbitUI {
     private static final long serialVersionUID = 1L;
 
     @Autowired
-    MyUI(final EventPushStrategy pushStrategy, final UIEventBus eventBus, final SpringViewProvider viewProvider,
-            final ApplicationContext context, final DashboardMenu dashboardMenu, final ErrorView errorview,
-            final NotificationUnreadButton notificationUnreadButton, final UiProperties uiProperties,
-            final VaadinMessageSource i18n) {
-        super(pushStrategy, eventBus, viewProvider, context, dashboardMenu, errorview, notificationUnreadButton,
-                uiProperties, i18n);
+    MyUI(final EventPushStrategy pushStrategy, final UIEventBus eventBus, final UIEventProvider eventProvider,
+            final SpringViewProvider viewProvider, final ApplicationContext context, final DashboardMenu dashboardMenu,
+            final ErrorView errorview, final NotificationUnreadButton notificationUnreadButton,
+            final UiProperties uiProperties, final VaadinMessageSource i18n) {
+        super(pushStrategy, eventBus, eventProvider, viewProvider, context, dashboardMenu, errorview,
+                notificationUnreadButton, uiProperties, i18n);
     }
 }

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DDISimulatedDevice.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DDISimulatedDevice.java
@@ -141,11 +141,7 @@ public class DDISimulatedDevice extends AbstractSimulatedDevice {
             break;
         }
 
-        final DdiStatus status = new DdiStatus(ExecutionStatus.CLOSED, new DdiResult(FinalResult.SUCCESS, null), null);
-
-        final DdiConfigData configData = new DdiConfigData(null, null, status, Collections.singletonMap(key, value),
-                updateMode);
-
+        final DdiConfigData configData = new DdiConfigData(Collections.singletonMap(key, value), updateMode);
         controllerResource.putConfigData(configData, super.getTenant(), super.getId());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0M6</version>
+      <version>0.3.0M7</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -47,7 +47,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0M6</hawkbit.version>
+      <hawkbit.version>0.3.0M7</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
       <!-- Release - START -->


### PR DESCRIPTION
As soon as `0.3.0M7` of hawkBit is available we need to adapt the UI classes in order to reflect the changes introduced by Vaadin 8 migration. While I was on the why I also fixed compile issue introduced by https://github.com/eclipse/hawkbit/pull/988 which would brake examples as soon as we move on to hawkBit `0.3.0M7`.

Note: The build failure is expected until the examples parent is pointing to 0.3.0M7 of hawkBit