### PR TITLE
JUnit5 support

### DIFF
--- a/hawkbit-device-simulator/pom.xml
+++ b/hawkbit-device-simulator/pom.xml
@@ -135,7 +135,7 @@
       </dependency>
       <dependency>
          <groupId>io.qameta.allure</groupId>
-         <artifactId>allure-junit4</artifactId>
+         <artifactId>allure-junit5</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/hawkbit-device-simulator/src/test/java/org/eclipse/hawkbit/simulator/AllowAllWebSecurityTest.java
+++ b/hawkbit-device-simulator/src/test/java/org/eclipse/hawkbit/simulator/AllowAllWebSecurityTest.java
@@ -15,7 +15,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 import org.eclipse.hawkbit.simulator.http.BasicAuthProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
 @Feature("Component Tests - Hawkbit Device Simulator")

--- a/hawkbit-device-simulator/src/test/java/org/eclipse/hawkbit/simulator/AuthenticatedWebSecurityTest.java
+++ b/hawkbit-device-simulator/src/test/java/org/eclipse/hawkbit/simulator/AuthenticatedWebSecurityTest.java
@@ -16,7 +16,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 import org.eclipse.hawkbit.simulator.http.BasicAuthProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 

--- a/hawkbit-device-simulator/src/test/java/org/eclipse/hawkbit/simulator/DdiWebSecurityTest.java
+++ b/hawkbit-device-simulator/src/test/java/org/eclipse/hawkbit/simulator/DdiWebSecurityTest.java
@@ -9,19 +9,18 @@
 package org.eclipse.hawkbit.simulator;
 
 import org.eclipse.hawkbit.simulator.amqp.AmqpProperties;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@RunWith(SpringRunner.class)
 @TestPropertySource(properties = {AmqpProperties.CONFIGURATION_ENABLED_PROPERTY + " = false"})
-public abstract class DdiWebSecurityTest {
+public class DdiWebSecurityTest {
 
     @Autowired
     protected MockMvc mockMvc;

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0M6</version>
+      <version>0.3.0M7</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -47,7 +47,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0M6</hawkbit.version>
+      <hawkbit.version>0.3.0M7</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
       <!-- Release - START -->


### PR DESCRIPTION
Reflecting changes from https://github.com/eclipse/hawkbit/pull/1063

Note: The build failure is expected until `0.3.0M7` of hawkBit is available containing required JUnit5 setup