### PR TITLE
Fix No access to view error

### DIFF
--- a/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyUI.java
+++ b/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyUI.java
@@ -38,7 +38,7 @@ import com.vaadin.spring.navigator.SpringViewProvider;
  *
  */
 @SpringUI
-@Push(value = PushMode.AUTOMATIC, transport = Transport.WEBSOCKET)
+@Push(value = PushMode.AUTOMATIC, transport = Transport.WEBSOCKET_XHR)
 @Title("hawkBit Theme example")
 @Theme(value = "exampletheme")
 public class MyUI extends AbstractHawkbitUI {


### PR DESCRIPTION
Changed UI push transport from WEBSOCKET to WEBSOCKET_XHR
to solve problems with Spring Security Context that cause
the No access to view error message.

Signed-off-by: Daniele Sergio <daniele.sergio@kynetics.com>