### PR TITLE
Use suffix only for creating multiple MgmtDistributionSetTypeRequestBodyPost

### DIFF
--- a/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/DistributionSetTypeBuilder.java
+++ b/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/DistributionSetTypeBuilder.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.mgmt.client.resource.builder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.hawkbit.mgmt.json.model.distributionsettype.MgmtDistributionSetTypeRequestBodyPost;
@@ -62,8 +62,8 @@ public class DistributionSetTypeBuilder {
 
     /**
      * @param softwareModuleTypeIds
-     *            the IDs of the software module types which should be mandatory
-     *            for the distribution set type
+     *            the IDs of the software module types which should be mandatory for
+     *            the distribution set type
      * @return the builder itself
      */
     public DistributionSetTypeBuilder mandatorymodules(final Long... softwareModuleTypeIds) {
@@ -78,8 +78,8 @@ public class DistributionSetTypeBuilder {
     /**
      * 
      * @param softwareModuleTypeIds
-     *            the IDs of the software module types which should be optional
-     *            for the distribution set type
+     *            the IDs of the software module types which should be optional for
+     *            the distribution set type
      * @return the builder itself
      */
     public DistributionSetTypeBuilder optionalmodules(final Long... softwareModuleTypeIds) {
@@ -93,44 +93,40 @@ public class DistributionSetTypeBuilder {
 
     /**
      * Builds a list with a single entry of
-     * {@link MgmtDistributionSetTypeRequestBodyPost} which can directly be used
-     * in the RESTful-API.
+     * {@link MgmtDistributionSetTypeRequestBodyPost} which can directly be used in
+     * the RESTful-API.
      * 
-     * @return a single entry list of
-     *         {@link MgmtDistributionSetTypeRequestBodyPost}
+     * @return a single entry list of {@link MgmtDistributionSetTypeRequestBodyPost}
      */
     public List<MgmtDistributionSetTypeRequestBodyPost> build() {
-        return Arrays.asList(doBuild(""));
+        return Collections.singletonList(doBuild(key, name));
     }
 
     /**
-     * Builds a list of multiple {@link MgmtDistributionSetTypeRequestBodyPost}
-     * to create multiple distribution set types at once. An increasing number
-     * will be added to the name and key of the distribution set type. The
-     * optional and mandatory software module types will remain the same.
+     * Builds a list of multiple {@link MgmtDistributionSetTypeRequestBodyPost} to
+     * create multiple distribution set types at once. An increasing number will be
+     * added to the name and key of the distribution set type. The optional and
+     * mandatory software module types will remain the same.
      * 
      * @param count
-     *            the amount of distribution sets type body which should be
-     *            created
+     *            the amount of distribution sets type body which should be created
      * @return a list of {@link MgmtDistributionSetTypeRequestBodyPost}
      */
     public List<MgmtDistributionSetTypeRequestBodyPost> buildAsList(final int count) {
         final List<MgmtDistributionSetTypeRequestBodyPost> bodyList = new ArrayList<>();
         for (int index = 0; index < count; index++) {
-            bodyList.add(doBuild(String.valueOf(index)));
+            bodyList.add(doBuild(key + index, name + index));
         }
         return bodyList;
-
     }
 
-    private MgmtDistributionSetTypeRequestBodyPost doBuild(final String suffix) {
+    private MgmtDistributionSetTypeRequestBodyPost doBuild(final String key, final String name) {
         final MgmtDistributionSetTypeRequestBodyPost body = new MgmtDistributionSetTypeRequestBodyPost();
-        body.setKey(key + suffix);
-        body.setName(name + suffix);
+        body.setKey(key);
+        body.setName(name);
         body.setDescription(description);
         body.setMandatorymodules(mandatorymodules);
         body.setOptionalmodules(optionalmodules);
         return body;
     }
-
 }

--- a/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/SoftwareModuleTypeBuilder.java
+++ b/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/SoftwareModuleTypeBuilder.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.mgmt.client.resource.builder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.hawkbit.mgmt.json.model.softwaremodule.MgmtSoftwareModuleRequestBodyPost;
@@ -71,41 +71,38 @@ public class SoftwareModuleTypeBuilder {
 
     /**
      * Builds a list with a single entry of
-     * {@link MgmtSoftwareModuleTypeRequestBodyPost} which can directly be used
-     * in the RESTful-API.
+     * {@link MgmtSoftwareModuleTypeRequestBodyPost} which can directly be used in
+     * the RESTful-API.
      * 
-     * @return a single entry list of
-     *         {@link MgmtSoftwareModuleTypeRequestBodyPost}
+     * @return a single entry list of {@link MgmtSoftwareModuleTypeRequestBodyPost}
      */
     public List<MgmtSoftwareModuleTypeRequestBodyPost> build() {
-        return Arrays.asList(doBuild(""));
+        return Collections.singletonList(doBuild(key, name));
     }
 
     /**
-     * Builds a list of multiple {@link MgmtSoftwareModuleTypeRequestBodyPost}
-     * to create multiple software module types at once. An increasing number
-     * will be added to the name and key of the software module type.
+     * Builds a list of multiple {@link MgmtSoftwareModuleTypeRequestBodyPost} to
+     * create multiple software module types at once. An increasing number will be
+     * added to the name and key of the software module type.
      * 
      * @param count
-     *            the amount of software module type bodies which should be
-     *            created
+     *            the amount of software module type bodies which should be created
      * @return a list of {@link MgmtSoftwareModuleTypeRequestBodyPost}
      */
     public List<MgmtSoftwareModuleTypeRequestBodyPost> buildAsList(final int count) {
         final List<MgmtSoftwareModuleTypeRequestBodyPost> bodyList = new ArrayList<>();
         for (int index = 0; index < count; index++) {
-            bodyList.add(doBuild(String.valueOf(index)));
+            bodyList.add(doBuild(key + index, name + index));
         }
         return bodyList;
     }
 
-    private MgmtSoftwareModuleTypeRequestBodyPost doBuild(final String suffix) {
+    private MgmtSoftwareModuleTypeRequestBodyPost doBuild(final String key, final String name) {
         final MgmtSoftwareModuleTypeRequestBodyPost body = new MgmtSoftwareModuleTypeRequestBodyPost();
-        body.setKey(key + suffix);
-        body.setName(name + suffix);
+        body.setKey(key);
+        body.setName(name);
         body.setDescription(description);
         body.setMaxAssignments(maxAssignments);
         return body;
     }
-
 }


### PR DESCRIPTION
While creating a single `MgmtDistributionSetTypeRequestBodyPost`/`MgmtSoftwareModuleTypeRequestBodyPost` with the corresponding `DistributionSetTypeBuilder`/`SoftwareModuleTypeBuilder` the `key` and `name` properties can get null as String values ("null") assigned because of the String concatenation with the empty String suffix. This PR will correct this behavior.

Signed-off-by: Florian Ruschbaschan <Florian.Ruschbaschan@bosch.io>