### PR TITLE
Introduce target type client and builder

### DIFF
--- a/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/MgmtTargetTypeClientResource.java
+++ b/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/MgmtTargetTypeClientResource.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.client.resource;
+
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetTypeRestApi;
+import org.springframework.cloud.openfeign.FeignClient;
+
+/**
+ * Client binding for the TargetType resource of the management API.
+ */
+@FeignClient(name = "MgmtTargetTypeClient", url = "${hawkbit.url:localhost:8080}")
+public interface MgmtTargetTypeClientResource extends MgmtTargetTypeRestApi {
+}

--- a/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetBuilder.java
+++ b/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetBuilder.java
@@ -29,6 +29,7 @@ public class TargetBuilder {
     private String description;
     private String address;
     private Boolean requestAttributes;
+    private Long targetType;
 
     /**
      * @param controllerId
@@ -37,6 +38,16 @@ public class TargetBuilder {
      */
     public TargetBuilder controllerId(final String controllerId) {
         this.controllerId = controllerId;
+        return this;
+    }
+
+    /**
+     * @param targetType
+     *            the ID of the target type
+     * @return the builder itself
+     */
+    public TargetBuilder targetType(final long targetType) {
+        this.targetType = targetType;
         return this;
     }
 
@@ -134,6 +145,7 @@ public class TargetBuilder {
         body.setDescription(description);
         body.setAddress(address);
         body.setRequestAttributes(requestAttributes);
+        body.setTargetType(targetType);
         return body;
     }
 

--- a/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetTypeBuilder.java
+++ b/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetTypeBuilder.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.client.resource.builder;
+
+import org.eclipse.hawkbit.mgmt.json.model.distributionsettype.MgmtDistributionSetTypeAssignment;
+import org.eclipse.hawkbit.mgmt.json.model.distributionsettype.MgmtDistributionSetTypeRequestBodyPost;
+import org.eclipse.hawkbit.mgmt.json.model.targettype.MgmtTargetTypeRequestBodyPost;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 
+ * Builder pattern for building {@link MgmtTargetTypeRequestBodyPost}.
+ *
+ */
+public class TargetTypeBuilder {
+
+    private String name;
+    private String description;
+    private String color;
+    private final List<MgmtDistributionSetTypeAssignment> compatibledistributionsettypes = new ArrayList<>();
+
+    /**
+     * @param name
+     *            the name of the target type
+     * @return the builder itself
+     */
+    public TargetTypeBuilder name(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * @param color
+     *            the color of the target type
+     * @return the builder itself
+     */
+    public TargetTypeBuilder color(final String color) {
+        this.color = color;
+        return this;
+    }
+
+    /**
+     * @param description
+     *            the description
+     * @return the builder itself
+     */
+    public TargetTypeBuilder description(final String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * @param distributionSetTypeIds
+     *            the IDs of the distribution set types which should be compatible
+     *            for the target type
+     * @return the builder itself
+     */
+    public TargetTypeBuilder compatibleDsSetTypes(final Long... distributionSetTypeIds) {
+        for (final Long id : distributionSetTypeIds) {
+            final MgmtDistributionSetTypeAssignment distributionSetTypeAssignment = new MgmtDistributionSetTypeAssignment();
+            distributionSetTypeAssignment.setId(id);
+            this.compatibledistributionsettypes.add(distributionSetTypeAssignment);
+        }
+        return this;
+    }
+
+    /**
+     * Builds a list with a single entry of
+     * {@link MgmtTargetTypeRequestBodyPost} which can directly be used
+     * in the RESTful-API.
+     * 
+     * @return a single entry list of
+     *         {@link MgmtDistributionSetTypeRequestBodyPost}
+     */
+    public List<MgmtTargetTypeRequestBodyPost> build() {
+        return Collections.singletonList(doBuild(""));
+    }
+
+    /**
+     * Builds a list of multiple {@link MgmtTargetTypeRequestBodyPost}
+     * to create multiple target types at once. An increasing number
+     * will be added to the name of the target type. The
+     * compatible dsSet types will remain the same.
+     * 
+     * @param count
+     *            the amount of target type body which should be
+     *            created
+     * @return a list of {@link MgmtTargetTypeRequestBodyPost}
+     */
+    public List<MgmtTargetTypeRequestBodyPost> buildAsList(final int count) {
+        final List<MgmtTargetTypeRequestBodyPost> bodyList = new ArrayList<>();
+        for (int index = 0; index < count; index++) {
+            bodyList.add(doBuild(String.valueOf(index)));
+        }
+        return bodyList;
+
+    }
+
+    private MgmtTargetTypeRequestBodyPost doBuild(final String suffix) {
+        final MgmtTargetTypeRequestBodyPost body = new MgmtTargetTypeRequestBodyPost();
+        body.setName(name + suffix);
+        body.setColour(color);
+        body.setDescription(description);
+        body.setCompatibleDsTypes(compatibledistributionsettypes);
+        return body;
+    }
+
+}


### PR DESCRIPTION
A target type entity and API has been introduced to Hawkbit. This is an extension to use the target type client and builder for target type rest API