### PR TITLE
Replacing self-managed SonarQube with Sonarcloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.3.0.bosch81</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -47,7 +47,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
+      <hawkbit.version>0.3.0.bosch81</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
       <!-- Release - START -->

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,6 @@
    </modules>
 
    <properties>
-      <!-- ************************ -->
-      <!-- Build/Release settings -->
-      <!-- ************************ -->
-      <maven.sonar.plugin.version>3.9.1.2184</maven.sonar.plugin.version>
-      
       <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
@@ -72,19 +67,6 @@
    </scm>
 
    <build>
-   
-      <pluginManagement>
-         <plugins>      
-        	<!-- override groupid that is set in maven to supress warning regarding relocation of sonar-maven-plugin -->
-	    	<!-- see https://stackoverflow.com/a/35289210 -->
-            <plugin>
-               <groupId>org.sonarsource.scanner.maven</groupId>
-               <artifactId>sonar-maven-plugin</artifactId>
-               <version>${maven.sonar.plugin.version}</version>
-            </plugin> 
-         </plugins>
-      </pluginManagement>   
-   
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0.bosch81</version>
+      <version>0.3.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -47,7 +47,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0.bosch81</hawkbit.version>
+      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
       <!-- Release - START -->
@@ -57,7 +57,6 @@
       <!-- Release - END -->
 
       <!-- Sonar - START -->
-      <sonar.github.repository>eclipse/hawkbit-examples</sonar.github.repository>
       <sonar.links.ci>https://circleci.com/gh/eclipse/hawkbit-examples</sonar.links.ci>
       <!-- Sonar - END -->
    </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,11 @@
    </modules>
 
    <properties>
-
+      <!-- ************************ -->
+      <!-- Build/Release settings -->
+      <!-- ************************ -->
+      <maven.sonar.plugin.version>3.9.1.2184</maven.sonar.plugin.version>
+      
       <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
@@ -68,6 +72,19 @@
    </scm>
 
    <build>
+   
+      <pluginManagement>
+         <plugins>      
+        	<!-- override groupid that is set in maven to supress warning regarding relocation of sonar-maven-plugin -->
+	    	<!-- see https://stackoverflow.com/a/35289210 -->
+            <plugin>
+               <groupId>org.sonarsource.scanner.maven</groupId>
+               <artifactId>sonar-maven-plugin</artifactId>
+               <version>${maven.sonar.plugin.version}</version>
+            </plugin> 
+         </plugins>
+      </pluginManagement>   
+   
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR contains the changes to replace the self-managed SonarQube with Sonarcloud for this repository.