### PR TITLE
Autostart of hawkbit device simulator fails with IllegalArgumentException

### DIFF
--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
@@ -38,6 +38,8 @@ public class DmfSenderService extends MessageService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DmfSenderService.class);
 
+    private static final byte[] EMPTY_BODY = new byte[0];
+
     private final String spExchange;
 
     private final SimulationProperties simulationProperties;
@@ -66,7 +68,7 @@ public class DmfSenderService extends MessageService {
         messageProperties.setReplyTo(amqpProperties.getSenderForSpExchange());
         messageProperties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
 
-        sendMessage(spExchange, new Message(null, messageProperties));
+        sendMessage(spExchange, new Message(EMPTY_BODY, messageProperties));
     }
 
     /**
@@ -252,7 +254,7 @@ public class DmfSenderService extends MessageService {
         messagePropertiesForSP.setHeader(MessageHeaderKey.SENDER, "simulator");
         messagePropertiesForSP.setContentType(MessageProperties.CONTENT_TYPE_JSON);
         messagePropertiesForSP.setReplyTo(amqpProperties.getSenderForSpExchange());
-        return new Message(null, messagePropertiesForSP);
+        return new Message(EMPTY_BODY, messagePropertiesForSP);
     }
 
     private MessageProperties createAttributeUpdateMessage(final String tenant, final String targetId) {

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.3.0.bosch81</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -47,7 +47,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
+      <hawkbit.version>0.3.0.bosch81</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
       <!-- Release - START -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0.bosch81</version>
+      <version>0.3.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -47,7 +47,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0.bosch81</hawkbit.version>
+      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <feign.extension.version>10.1.0</feign.extension.version>
       
       <!-- Release - START -->


### PR DESCRIPTION
The autostart functionality of the hawkbit device simulator fails with the following exception:

2022-10-17 11:13:47.581 ERROR 1 — [main] o.s.boot.SpringApplication : Application run failed
java.lang.IllegalArgumentException: 'body' cannot be null
    at org.springframework.util.Assert.notNull(Assert.java:201)
    at org.springframework.amqp.core.Message.<init>(Message.java:75)
    at org.eclipse.hawkbit.simulator.amqp.DmfSenderService.thingCreatedMessage(DmfSenderService.java:255)
    at org.eclipse.hawkbit.simulator.amqp.DmfSenderService.createOrUpdateThing(DmfSenderService.java:206)
    at org.eclipse.hawkbit.simulator.SimulatedDeviceFactory.createDmfDevice(SimulatedDeviceFactory.java:108)
    at org.eclipse.hawkbit.simulator.SimulatedDeviceFactory.createSimulatedDevice(SimulatedDeviceFactory.java:78)
    at org.eclipse.hawkbit.simulator.SimulatedDeviceFactory.createSimulatedDeviceWithImmediatePoll(SimulatedDeviceFactory.java:139)
    at org.eclipse.hawkbit.simulator.SimulatorStartup.lambda$onApplicationEvent$0(SimulatorStartup.java:54)
    at java.base/java.util.ArrayList.forEach(Unknown Source)
    at org.eclipse.hawkbit.simulator.SimulatorStartup.onApplicationEvent(SimulatorStartup.java:48)
    at org.eclipse.hawkbit.simulator.SimulatorStartup.onApplicationEvent(SimulatorStartup.java:27)
