### PR TITLE
Feature/adapt to user confirmation flow

### DIFF
--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DDISimulatedDevice.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DDISimulatedDevice.java
@@ -106,7 +106,7 @@ public class DDISimulatedDevice extends AbstractSimulatedDevice {
             } else {
                 getRequiredLink(DEPLOYMENT_BASE_LINK).flatMap(this::getActionWithDeployment).ifPresent(actionWithDeployment -> {
                     final Long actionId = actionWithDeployment.getKey();
-                    final DdiDeployment deployment = actionWithDeployment.getValue().getDeployment();
+                    final  DdiDeployment deployment = actionWithDeployment.getValue().getDeployment();
                     final HandlingType updateType = deployment.getUpdate();
                     final List<DdiChunk> modules = deployment.getChunks();
 

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DDISimulatedDevice.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DDISimulatedDevice.java
@@ -58,9 +58,9 @@ public class DDISimulatedDevice extends AbstractSimulatedDevice {
 
     private final String gatewayToken;
 
-    private final String DEPLOYMENT_BASE_LINK = "deploymentBase";
+    private static final String DEPLOYMENT_BASE_LINK = "deploymentBase";
 
-    private final String CONFIRMATION_BASE_LINK = "confirmationBase";
+    private static final String CONFIRMATION_BASE_LINK = "confirmationBase";
 
     private volatile boolean removed;
     private volatile Long currentActionId;
@@ -214,8 +214,8 @@ public class DDISimulatedDevice extends AbstractSimulatedDevice {
     }
 
     private void sendConfirmationFeedback(final long actionId) {
-        DdiConfirmationFeedback ddiConfirmationFeedback = new DdiConfirmationFeedback(
-                DdiConfirmationFeedback.Confirmation.CONFIRMED, 0, Arrays.asList(
+        final DdiConfirmationFeedback ddiConfirmationFeedback = new DdiConfirmationFeedback(
+                DdiConfirmationFeedback.Confirmation.CONFIRMED, 0, Collections.singletonList(
                 "the confirmation status for the device is" + DdiConfirmationFeedback.Confirmation.CONFIRMED));
         controllerResource.postConfirmationActionFeedback(ddiConfirmationFeedback, getTenant(), getId(), actionId);
     }

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
@@ -100,7 +100,12 @@ public class UpdateStatus {
         /**
          * Device is finished with downloading.
          */
-        DOWNLOADED;
+        DOWNLOADED,
+
+        /**
+         * Device has been approved for the installation.
+         */
+        CONFIRMED;
     }
 
 }

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
@@ -54,7 +54,7 @@ public class DmfReceiverService extends MessageService {
 
     private final Set<Long> openActions = Collections.synchronizedSet(new HashSet<>());
 
-    private final String REGEX_EXTRACT_ACTIONID = "[^0-9]";
+    private static final String REGEX_EXTRACT_ACTIONID = "[^0-9]";
 
     /**
      * Constructor.
@@ -210,7 +210,8 @@ public class DmfReceiverService extends MessageService {
 
     private long extractActionIdFrom(final Message message) {
         final String messageAsString = message.toString();
-        final String requiredMessageContent = messageAsString.substring(messageAsString.indexOf("{") + 1, messageAsString.indexOf("}"));
+        final String requiredMessageContent = messageAsString
+                .substring(messageAsString.indexOf('{') + 1, messageAsString.indexOf('}'));
         final String[] splitMessageContent = requiredMessageContent.split(",");
         return Long.parseLong(splitMessageContent[0].replaceAll(REGEX_EXTRACT_ACTIONID, ""));
     }

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
@@ -180,6 +180,7 @@ public class DmfReceiverService extends MessageService {
         switch (eventTopic) {
         case CONFIRM:
             handleConfirmation(message, thingId);
+            break;
         case DOWNLOAD_AND_INSTALL:
         case DOWNLOAD:
             handleUpdateProcess(message, thingId, eventTopic);
@@ -200,7 +201,7 @@ public class DmfReceiverService extends MessageService {
     }
 
     private void handleConfirmation(final Message message, final String thingId) {
-        AbstractSimulatedDevice device = repository.get(getTenant(message), thingId);
+        final AbstractSimulatedDevice device = repository.get(getTenant(message), thingId);
         device.setUpdateStatus(new UpdateStatus(UpdateStatus.ResponseStatus.CONFIRMED, "Simulator : Action is confirmed"));
         final Long actionId = extractActionIdFrom(message);
         LOGGER.info("Action with id {} is confirmed be the device for installation", actionId);

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
@@ -54,6 +54,8 @@ public class DmfReceiverService extends MessageService {
 
     private final Set<Long> openActions = Collections.synchronizedSet(new HashSet<>());
 
+    private final String REGEX_EXTRACT_ACTIONID = "[^0-9]";
+
     /**
      * Constructor.
      * 
@@ -207,9 +209,9 @@ public class DmfReceiverService extends MessageService {
 
     private long extractActionIdFrom(final Message message) {
         final String messageAsString = message.toString();
-        String result1 = message.toString().substring(messageAsString.indexOf("{") + 1, messageAsString.indexOf("}"));
-        String[] myStrings = result1.split(",");
-        return Long.parseLong(myStrings[0].replaceAll("[^0-9]", ""));
+        final String requiredMessageContent = messageAsString.substring(messageAsString.indexOf("{") + 1, messageAsString.indexOf("}"));
+        final String[] splitMessageContent = requiredMessageContent.split(",");
+        return Long.parseLong(splitMessageContent[0].replaceAll(REGEX_EXTRACT_ACTIONID, ""));
     }
 
     private void handleMultiActionRequest(final Message message, final String thingId) {

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfReceiverService.java
@@ -25,6 +25,7 @@ import org.eclipse.hawkbit.dmf.json.model.DmfMultiActionRequest;
 import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice;
 import org.eclipse.hawkbit.simulator.DeviceSimulatorRepository;
 import org.eclipse.hawkbit.simulator.DeviceSimulatorUpdater;
+import org.eclipse.hawkbit.simulator.UpdateStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
@@ -175,6 +176,8 @@ public class DmfReceiverService extends MessageService {
         @SuppressWarnings({ "squid:S2259" })
         final EventTopic eventTopic = EventTopic.valueOf(eventHeader.toString());
         switch (eventTopic) {
+        case CONFIRM:
+            handleConfirmation(message, thingId);
         case DOWNLOAD_AND_INSTALL:
         case DOWNLOAD:
             handleUpdateProcess(message, thingId, eventTopic);
@@ -192,6 +195,21 @@ public class DmfReceiverService extends MessageService {
             LOGGER.info("No valid event property: {}", eventTopic);
             break;
         }
+    }
+
+    private void handleConfirmation(final Message message, final String thingId) {
+        AbstractSimulatedDevice device = repository.get(getTenant(message), thingId);
+        device.setUpdateStatus(new UpdateStatus(UpdateStatus.ResponseStatus.CONFIRMED, "Simulator : Action is confirmed"));
+        final Long actionId = extractActionIdFrom(message);
+        LOGGER.info("Action with id {} is confirmed be the device for installation", actionId);
+        sendFeedback(actionId, device);
+    }
+
+    private long extractActionIdFrom(final Message message) {
+        final String messageAsString = message.toString();
+        String result1 = message.toString().substring(messageAsString.indexOf("{") + 1, messageAsString.indexOf("}"));
+        String[] myStrings = result1.split(",");
+        return Long.parseLong(myStrings[0].replaceAll("[^0-9]", ""));
     }
 
     private void handleMultiActionRequest(final Message message, final String thingId) {
@@ -246,7 +264,7 @@ public class DmfReceiverService extends MessageService {
 
     private void handleCancelDownloadAction(final Message message, final String thingId) {
         final String tenant = getTenant(message);
-        final Long actionId = convertMessage(message, Long.class);
+        final Long actionId = extractActionIdFrom(message);
 
         processCancelDownloadAction(thingId, tenant, actionId);
     }
@@ -301,6 +319,10 @@ public class DmfReceiverService extends MessageService {
             break;
         case RUNNING:
             spSenderService.sendActionStatusMessage(device.getTenant(), DmfActionStatus.RUNNING,
+                    device.getUpdateStatus().getStatusMessages(), actionId);
+            break;
+        case CONFIRMED:
+            spSenderService.sendActionStatusMessage(device.getTenant(), DmfActionStatus.CONFIRMED,
                     device.getUpdateStatus().getStatusMessages(), actionId);
             break;
         default:

--- a/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
+++ b/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/DmfSenderService.java
@@ -94,7 +94,7 @@ public class DmfSenderService extends MessageService {
      *            list of messages for error
      */
     public void finishUpdateProcessWithError(final SimulatedUpdate update, final List<String> updateResultMessages) {
-        sendErrorgMessage(update, updateResultMessages);
+        sendErrorMessage(update, updateResultMessages);
         LOGGER.debug("Update process finished with error \"{}\" reported by thing {}", updateResultMessages,
                 update.getThingId());
     }
@@ -291,27 +291,40 @@ public class DmfSenderService extends MessageService {
     /**
      * Send error message to SP.
      *
-     * @param context
-     *            the current context
+     * @param update
+     *            the simulated update
      * @param updateResultMessages
      *            a list of descriptions according the update process
      */
-    private void sendErrorgMessage(final SimulatedUpdate update, final List<String> updateResultMessages) {
+    private void sendErrorMessage(final SimulatedUpdate update, final List<String> updateResultMessages) {
         final Message message = createActionStatusMessage(update, updateResultMessages, DmfActionStatus.ERROR);
+        sendMessage(spExchange, message);
+    }
+
+    /**
+     * Send confirmation message to SP.
+     *
+     * @param update
+     *            the simulated update
+     * @param updateResultMessages
+     *            a list of descriptions according the update process
+     */
+    public void sendConfirmationMessage(final SimulatedUpdate update, final List<String> updateResultMessages) {
+        final Message message = createActionStatusMessage(update, updateResultMessages, DmfActionStatus.CONFIRMED);
         sendMessage(spExchange, message);
     }
 
     /**
      * Create a action status message.
      *
+     * @param tenant
+     *            the tenant
      * @param actionStatus
      *            the ActionStatus
-     * @param actionMessage
-     *            the message description
+     * @param updateResultMessages
+     *            the list of update result messages
      * @param actionId
      *            the action id
-     * @param cacheValue
-     *            the cacheValue value
      */
     private Message createActionStatusMessage(final String tenant, final DmfActionStatus actionStatus,
             final List<String> updateResultMessages, final Long actionId) {
@@ -345,5 +358,4 @@ public class DmfSenderService extends MessageService {
             final DmfActionStatus status) {
         return createActionStatusMessage(update.getTenant(), status, updateResultMessages, update.getActionId());
     }
-
 }

--- a/hawkbit-example-mgmt-simulator/src/main/java/org/eclipse/hawkbit/mgmt/client/scenarios/ConfigurableScenario.java
+++ b/hawkbit-example-mgmt-simulator/src/main/java/org/eclipse/hawkbit/mgmt/client/scenarios/ConfigurableScenario.java
@@ -160,7 +160,7 @@ public class ConfigurableScenario {
 
         PagedList<MgmtRolloutResponseBody> rollouts;
 
-        while ((rollouts = rolloutResource.getRollouts(0, PAGE_SIZE, null, null).getBody()) != null
+        while ((rollouts = rolloutResource.getRollouts(0, PAGE_SIZE, null, null, "compact").getBody()) != null
                 && rollouts.getTotal() > 0) {
             rollouts.getContent().parallelStream().forEach(rollout -> {
                 rolloutResource.delete(rollout.getRolloutId());


### PR DESCRIPTION
Adapted device simulator to handle User Confirmation Flow while simulating devices via DDI or DMF. Incase the user has turned on the tenant configuration to "Request confirmation for actions before proceeding with download/install process." then the simulator will provide the approval and change the status of the action from WAIT_FOR_CONFIRMATION to RUNNING and simulate the rest of the statuses of the installation.